### PR TITLE
download: limit history of git clone

### DIFF
--- a/root/usr/share/nethserver-blacklist/download
+++ b/root/usr/share/nethserver-blacklist/download
@@ -82,7 +82,7 @@ fi
 # Create repository clone
 if [ ! -d "$DEST_DIR/.git" ]; then
     debug "Cloning repository"
-    git clone $quiet $proto$auth$url $DEST_DIR
+    git clone --depth 1 $quiet $proto$auth$url $DEST_DIR
     if [ $? -gt 0 ]; then
         exit_error "Can't download blacklist repository"
     fi


### PR DESCRIPTION
Create a shallow clone with a history truncated at the last commit, we
need only the last version when the lists are downloaded for the first
time.

NethServer/dev#6207