### PR TITLE
dns: just reload ftl

### DIFF
--- a/root/usr/share/nethserver-blacklist/load-dnss
+++ b/root/usr/share/nethserver-blacklist/load-dnss
@@ -122,6 +122,7 @@ count=$($SQLITE $GRAVITY_DB 'SELECT COUNT(DISTINCT domain) FROM vw_gravity;')
 $SQLITE "$GRAVITY_DB" "INSERT OR REPLACE INTO info (property, value) VALUES ('gravity_count', $count);"
 debug "Update total domains in gravity db. There are $count domains"
 
-# restart ftl and load new domains
-debug "Restart ftl"
-/usr/bin/systemctl restart ftl
+# reload lists
+debug "Reloading lists"
+PID=$(/bin/systemctl -p MainPID show ftl | cut -d '=' -f2)
+kill -SIGRTMIN $PID


### PR DESCRIPTION
Do not restart ftl to avoid service interruption.
The service can be reloaded using the following signals:
- SIGRTMIN: just reload the lists
- SIGHUP: flush DNS cache

Both signals will NOT re-read any *.conf files.

NethServer/dev#6212