### PR TITLE
cron. move download dns once per day

### DIFF
--- a/root/etc/e-smith/templates/etc/cron.d/nethserver-blacklist/10base
+++ b/root/etc/e-smith/templates/etc/cron.d/nethserver-blacklist/10base
@@ -10,7 +10,7 @@
 
     my $dns_status = $ftl{'status'} || 'disabled';
     if ($dns_status eq 'enabled') {
-        $OUT .= '*/20 * * * * root sleep $(( ( RANDOM \% 60 ) )); /usr/share/nethserver-blacklist/download dnss'
+        $OUT .= '0 23 * * * root sleep $(( ( RANDOM \% 60 ) )); /usr/share/nethserver-blacklist/download dnss'
     } else {
         $OUT .= "# Blacklists (dns) are disabled"
     }

--- a/root/etc/e-smith/templates/etc/cron.d/nethserver-blacklist/10base
+++ b/root/etc/e-smith/templates/etc/cron.d/nethserver-blacklist/10base
@@ -10,7 +10,7 @@
 
     my $dns_status = $ftl{'status'} || 'disabled';
     if ($dns_status eq 'enabled') {
-        $OUT .= '0 23 * * * root sleep $(( ( RANDOM \% 60 ) )); /usr/share/nethserver-blacklist/download dnss'
+        $OUT .= '0 23 * * * root sleep $(( ( RANDOM \% 900 ) )); /usr/share/nethserver-blacklist/download dnss'
     } else {
         $OUT .= "# Blacklists (dns) are disabled"
     }


### PR DESCRIPTION
During domain list reloading, `ftl` may cause disruptions and clients can't resolve correctly DNS. With this PR we move the download of the new domains once per day at `23:00` 

NethServer/dev#6212