### PR TITLE
Better logrotate

### DIFF
--- a/root/etc/logrotate.d/pihole
+++ b/root/etc/logrotate.d/pihole
@@ -6,4 +6,5 @@
         delaycompress
         notifempty
         nomail
+        missingok
 }

--- a/root/etc/logrotate.d/pihole
+++ b/root/etc/logrotate.d/pihole
@@ -1,8 +1,5 @@
 /var/log/pihole-FTL.log {
-        weekly
         copytruncate
-        rotate 3
-        compress
         delaycompress
         notifempty
         nomail


### PR DESCRIPTION
- use system default logorate configuration
- avoid error if `/var/log/pihole-FTL.log` is missing

NethServer/dev#6226