### PR TITLE
load-dns: do not fail if FTL is not running

### DIFF
--- a/root/usr/share/nethserver-blacklist/load-dnss
+++ b/root/usr/share/nethserver-blacklist/load-dnss
@@ -124,5 +124,8 @@ debug "Update total domains in gravity db. There are $count domains"
 
 # reload lists
 debug "Reloading lists"
-PID=$(/bin/systemctl -p MainPID show ftl | cut -d '=' -f2)
-kill -SIGRTMIN $PID
+/bin/systemctl is-active ftl -q
+if [ $? -eq 0 ]; then
+    PID=$(/bin/systemctl -p MainPID show ftl | cut -d '=' -f2)
+    kill -SIGRTMIN $PID
+fi


### PR DESCRIPTION
Before the fix, if FTL was not running, the script was sending a SIGRTMIN
signal to the PID 0, causing an abnormal event termination with
"Real-time signal 0" error.

NethServer/dev#6444