### PR TITLE
Display missing DNS & IPSEC blacklist

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/blrules/30blacklist
+++ b/root/etc/e-smith/templates/etc/shorewall/blrules/30blacklist
@@ -46,11 +46,18 @@
 
 
         # Enable selected blacklist categories
+
+        # retrieve the list of valid sets and compare it later
+        my %params = map { $_ => 1 } split(/\n/, `/usr/sbin/ipset list -name`);
+
         my @lists = split(/,/, $blacklist{'Categories'});
         # remove extension part, add 'bl-' prefix
         @lists = map { substr("bl-$_", 0, 31)  } @lists;
 
         foreach my $name (@lists) {
+            # if the set does not exist use next item
+            next unless (exists ($params{$name}));
+
             # green interface
             $OUT .= "BLACKLIST\tnet:+$name\tloc\n";
             $OUT .= "BLACKLIST\tloc\tnet:+$name\n";

--- a/root/etc/e-smith/templates/etc/shorewall/blrules/30geoip
+++ b/root/etc/e-smith/templates/etc/shorewall/blrules/30geoip
@@ -46,11 +46,17 @@
 
 
         # Enable selected blacklist categories
+
+        # retrieve the list of valid sets and compare it later
+        my %params = map { $_ => 1 } split(/\n/, `/usr/sbin/ipset list -name`);
         my @lists = split(/,/, $geoip{'Categories'});
         # remove extension part, add 'geo-' prefix
         @lists = map { substr("geo-$_", 0, 31)  } @lists;
 
         foreach my $name (@lists) {
+            # if the set does not exist use next item
+            next unless (exists ($params{$name}));
+
             # green interface
             $OUT .= "BLACKLIST\tnet:+$name\tloc\n";
             $OUT .= "BLACKLIST\tloc\tnet:+$name\n";

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -14,6 +14,7 @@
     "next": "Next",
     "prev": "Previous",
     "of": "of",
+    "missing": "Missing",
     "rows_per_page": "Rows per page",
     "all": "All",
     "close": "Close",

--- a/ui/src/views/DnsBlacklist.vue
+++ b/ui/src/views/DnsBlacklist.vue
@@ -280,11 +280,14 @@
                   :class="['checkbox-label', {'gray': (!props.row.enabled || !config.status)}]"
                 >
                   <span
-                    :class="['category-status-icon', 'pficon', (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
+                    :class="['category-status-icon', 'pficon', (props.row.missing && config.status) ? ['pficon-warning-triangle-o', 'orange'] : (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
                   ></span>
-                  <span
+                  <span v-if="(!props.row.missing && config.status)"
                     :class="{'green': (props.row.enabled && config.status)}"
                   >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}</span>
+                  <span v-if="(props.row.missing && config.status)"
+                    class="orange"
+                  >{{ $t('missing') }}</span>
                 </label>
               </span>
               <span v-else-if="props.column.field == 'confidence'">
@@ -294,7 +297,7 @@
                 >
                   <span
                     :class="['confidence', {'green': (props.row.enabled && config.status && props.row.confidence > 6)},
-                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)}]"
+                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)},{'orange': (props.row.missing && config.status)}]"
                   >
                     <span v-if="props.row.confidence > 0">{{props.row.confidence}}/10</span>
                     <span v-else>{{ $t('unknown') }}</span>
@@ -550,6 +553,8 @@ export default {
 
             if (categoryFound) {
               categoryFound.enabled = true;
+            } else if (enabledCategory !== '') {
+              categories.push({"id":enabledCategory,"enabled":true,"missing":true,"selected":false});
             }
           });
           context.allCategories = categories;

--- a/ui/src/views/DnsBlacklist.vue
+++ b/ui/src/views/DnsBlacklist.vue
@@ -282,12 +282,12 @@
                   <span
                     :class="['category-status-icon', 'pficon', (props.row.missing && config.status) ? ['pficon-warning-triangle-o', 'orange'] : (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
                   ></span>
-                  <span v-if="(!props.row.missing && config.status)"
-                    :class="{'green': (props.row.enabled && config.status)}"
-                  >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}</span>
-                  <span v-if="(props.row.missing && config.status)"
-                    class="orange"
-                  >{{ $t('missing') }}</span>
+                  <span v-if="!props.row.missing" :class="{'green': (props.row.enabled && config.status)}" 
+                    >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}
+                  </span>
+                  <span v-else :class="[(props.row.missing && config.status) ? 'orange':'gray']"
+                    >{{ $t('missing') }}
+                  </span>
                 </label>
               </span>
               <span v-else-if="props.column.field == 'confidence'">
@@ -297,7 +297,7 @@
                 >
                   <span
                     :class="['confidence', {'green': (props.row.enabled && config.status && props.row.confidence > 6)},
-                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)},{'orange': (props.row.missing && config.status)}]"
+                    {'orange': config.status && (props.row.enabled && props.row.confidence <= 6 || props.row.missing)}]"
                   >
                     <span v-if="props.row.confidence > 0">{{props.row.confidence}}/10</span>
                     <span v-else>{{ $t('unknown') }}</span>

--- a/ui/src/views/IpBlacklist.vue
+++ b/ui/src/views/IpBlacklist.vue
@@ -258,12 +258,12 @@
                   <span
                     :class="['category-status-icon', 'pficon', (props.row.missing && config.status) ? ['pficon-warning-triangle-o', 'orange'] : (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
                   ></span>
-                  <span v-if="(!props.row.missing && config.status)"
-                    :class="{'green': (props.row.enabled && config.status)}"
-                  >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}</span>
-                  <span v-if="(props.row.missing && config.status)"
-                    class="orange"
-                  >{{ $t('missing') }}</span>
+                  <span v-if="!props.row.missing" :class="{'green': (props.row.enabled && config.status)}" 
+                    >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}
+                  </span>
+                  <span v-else :class="[(props.row.missing && config.status) ? 'orange':'gray']"
+                    >{{ $t('missing') }}
+                  </span>
                 </label>
               </span>
               <span v-else-if="props.column.field == 'confidence'">
@@ -273,7 +273,7 @@
                 >
                   <span
                     :class="['confidence', {'green': (props.row.enabled && config.status && props.row.confidence > 6)},
-                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)},{'orange': (props.row.missing && config.status)}]"
+                    {'orange': config.status && (props.row.enabled && props.row.confidence <= 6 || props.row.missing)}]"
                   >
                     <span v-if="props.row.confidence > 0">{{props.row.confidence}}/10</span>
                     <span v-else>{{ $t('unknown') }}</span>

--- a/ui/src/views/IpBlacklist.vue
+++ b/ui/src/views/IpBlacklist.vue
@@ -256,11 +256,14 @@
                   :class="['checkbox-label', {'gray': (!props.row.enabled || !config.status)}]"
                 >
                   <span
-                    :class="['category-status-icon', 'pficon', (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
+                    :class="['category-status-icon', 'pficon', (props.row.missing && config.status) ? ['pficon-warning-triangle-o', 'orange'] : (props.row.enabled && config.status) ? ['pficon-ok', 'green'] : 'pficon-off']"
                   ></span>
-                  <span
+                  <span v-if="(!props.row.missing && config.status)"
                     :class="{'green': (props.row.enabled && config.status)}"
                   >{{ (props.row.enabled && config.status) ? $t('enabled') : $t('disabled') }}</span>
+                  <span v-if="(props.row.missing && config.status)"
+                    class="orange"
+                  >{{ $t('missing') }}</span>
                 </label>
               </span>
               <span v-else-if="props.column.field == 'confidence'">
@@ -270,7 +273,7 @@
                 >
                   <span
                     :class="['confidence', {'green': (props.row.enabled && config.status && props.row.confidence > 6)},
-                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)}]"
+                    {'orange': (props.row.enabled && config.status && props.row.confidence <= 6)},{'orange': (props.row.missing && config.status)}]"
                   >
                     <span v-if="props.row.confidence > 0">{{props.row.confidence}}/10</span>
                     <span v-else>{{ $t('unknown') }}</span>
@@ -512,6 +515,8 @@ export default {
 
               if (categoryFound) {
                 categoryFound.enabled = true;
+              } else if (enabledCategory !== '') {
+                categories.push({"id":enabledCategory,"enabled":true,"missing":true,"selected":false});
               }
             });
             context.allCategories = categories;


### PR DESCRIPTION
If a remote DNS or IPSEC Blacklist is enabled but not more available in the GIT repository, this can lead to issue when shorewall is restarted.

We need a NFR  to still display them in the list


![Screenshot - 2021-04-09T095828 680](https://user-images.githubusercontent.com/3164851/114148565-3443f380-991a-11eb-8059-5fec9c528408.png)
![Screenshot - 2021-04-09T095604 301](https://user-images.githubusercontent.com/3164851/114148570-34dc8a00-991a-11eb-9145-d80bf58c28f1.png)
![Screenshot - 2021-04-09T095416 248](https://user-images.githubusercontent.com/3164851/114148572-34dc8a00-991a-11eb-8189-25fd20578333.png)
![Screenshot - 2021-04-09T095354 330](https://user-images.githubusercontent.com/3164851/114148573-34dc8a00-991a-11eb-8012-665a92b73d49.png)

https://github.com/NethServer/dev/issues/6481