### PR TITLE
FTL must be restarted after host modification

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -70,3 +70,12 @@ validator_actions($_, qw(
     fwobject-host-delete
     fwobject-cidr-delete
 ));
+
+
+#---------------------------------------------------
+# After each host modification we need to restart ftl
+#---------------------------------------------------
+
+foreach (qw(host-create host-delete host-modify)) {
+    event_services($_, 'ftl' => 'restart');
+}


### PR DESCRIPTION
Relative to https://trello.com/c/xai6kkoD/262-ftl-cache

When we create, modify or delete a host inside dnsmasq we have to restart `ftl` to clear its cache

https://github.com/NethServer/dev/issues/6499