### PR TITLE
Do not verify the ssl certificate of ipdeny

### DIFF
--- a/root/usr/share/nethserver-blacklist/geoip
+++ b/root/usr/share/nethserver-blacklist/geoip
@@ -29,7 +29,7 @@ URL=$(/sbin/e-smith/db configuration getprop geoip Url)
 
 # download and extract
 pushd $tmp_dir
-/usr/bin/wget $URL >/dev/null 2>&1
+/usr/bin/wget $URL --no-check-certificate >/dev/null 2>&1
 tar -xf all-zones.tar.gz
 for j in *.zone
 do


### PR DESCRIPTION
The ssl certificate of ipdeny is obsolete since may 2021, we have an issue when we try to download by wget